### PR TITLE
setting supports on the linux_user resource is deprecated

### DIFF
--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -3,7 +3,7 @@ user node['prosody']['user'] do
   comment 'Prosody XMPP Server'
   home '/var/lib/prosody'
   shell '/bin/false'
-  supports :manage_home => true
+  manage_home true
   action :create
 end
 


### PR DESCRIPTION
Remove the `supports` property for `manage_home`.

Fixes a bug I ran into wrapping this cookbook

```
     Failure/Error: @chef_run.converge(described_recipe)
     
     NoMethodError:
       undefined method `supports' for Chef::Resource::User::LinuxUser
     # /tmp/d20180305-7524-nojcc6/cookbooks/prosody/recipes/_common.rb:6:in `block in from_file'
     # /tmp/d20180305-7524-nojcc6/cookbooks/prosody/recipes/_common.rb:1:in `from_file'
     # /tmp/d20180305-7524-nojcc6/cookbooks/prosody/recipes/source.rb:21:in `from_file'
     # /tmp/d20180305-7524-nojcc6/cookbooks/prosody/recipes/install.rb:22:in `from_file'
     # /tmp/d20180305-7524-nojcc6/cookbooks/prosody/recipes/default.rb:21:in `from_file'
     # /tmp/d20180305-7524-nojcc6/cookbooks/paramount/recipes/_prosody.rb:11:in `from_file'
     # ./test/unit/spec/prosody_spec.rb:18:in `block (6 levels) in <top (required)>'
```